### PR TITLE
{feat} 그룹 카테고리에 따라 그룹 목록을 조회하는 기능 추가

### DIFF
--- a/MathCaptain/weakness/src/main/java/MathCaptain/weakness/Group/controller/GroupController.java
+++ b/MathCaptain/weakness/src/main/java/MathCaptain/weakness/Group/controller/GroupController.java
@@ -146,4 +146,9 @@ public class GroupController {
     public ApiResponse<GroupResponseDto> searchGroup(@RequestBody GroupSearchRequestDto groupSearchRequestDto) {
         return ApiResponse.ok(groupService.getGroupInfo(groupSearchRequestDto.getGroupName()));
     }
+
+    @GetMapping("/group/total")
+    public ApiResponse<?> getGroups(@RequestParam(required = false) String category) {
+        return groupService.getGroups(category);
+    }
 }

--- a/MathCaptain/weakness/src/main/java/MathCaptain/weakness/Group/repository/GroupRepository.java
+++ b/MathCaptain/weakness/src/main/java/MathCaptain/weakness/Group/repository/GroupRepository.java
@@ -1,6 +1,7 @@
 package MathCaptain.weakness.Group.repository;
 
 import MathCaptain.weakness.Group.domain.Group;
+import MathCaptain.weakness.Group.enums.CategoryStatus;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.data.domain.Page;
@@ -19,6 +20,8 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
     Optional<Group> findByName(String groupName);
 
     Boolean existsByName(String groupName);
+
+    Optional<Group> findAllByCategory(CategoryStatus category);
 
     @Query("SELECT g FROM Group g ORDER BY g.groupPoint DESC")
     Page<Group> findAllOrderByGroupPoint (Pageable pageable);

--- a/MathCaptain/weakness/src/main/java/MathCaptain/weakness/Group/service/GroupService.java
+++ b/MathCaptain/weakness/src/main/java/MathCaptain/weakness/Group/service/GroupService.java
@@ -8,6 +8,7 @@ import MathCaptain.weakness.Group.dto.request.GroupUpdateRequestDto;
 import MathCaptain.weakness.Group.dto.response.GroupDetailResponseDto;
 import MathCaptain.weakness.Group.dto.response.GroupResponseDto;
 import MathCaptain.weakness.Group.dto.response.UserGroupCardResponseDto;
+import MathCaptain.weakness.Group.enums.CategoryStatus;
 import MathCaptain.weakness.Record.repository.RecordRepository;
 import MathCaptain.weakness.Record.service.RecordService;
 import MathCaptain.weakness.User.domain.UserDetailsImpl;
@@ -180,6 +181,27 @@ public class GroupService {
                 })
                 .toList();
 
+    }
+
+    public ApiResponse<?> getGroups(String category) {
+
+        if (category == null) {
+            return ApiResponse.ok(groupRepository.findAll().stream()
+                    .map(this::buildGroupResponseDto)
+                    .toList());
+        }
+        try {
+            // category를 CategoryStatus로 변환
+            CategoryStatus categoryStatus = CategoryStatus.valueOf(category.toUpperCase());
+
+            // 특정 카테고리의 그룹 반환
+            return ApiResponse.ok(groupRepository.findAllByCategory(categoryStatus).stream()
+                    .map(this::buildGroupResponseDto)
+                    .toList());
+        } catch (IllegalArgumentException e) {
+            // 잘못된 카테고리 값 처리
+            return ApiResponse.fail("유효하지 않은 카테고리입니다: ", category);
+        }
     }
 
     /// 비지니스 로직


### PR DESCRIPTION
# 그룹 카테고리에 따라 그룹 목록을 조회하는 기능 추가
쿼리파라미터를 통해 카테고리별 조회 가능
- ?category={Category}
- 쿼리 파라미터가 없는 경우엔 전체 조회