### PR TITLE
[fix] 채팅 수정 - 요청시 userId를 받도록 수정

### DIFF
--- a/MathCaptain/weakness/src/main/java/MathCaptain/weakness/domain/Chat/controller/ChatController.java
+++ b/MathCaptain/weakness/src/main/java/MathCaptain/weakness/domain/Chat/controller/ChatController.java
@@ -8,6 +8,8 @@ import MathCaptain.weakness.global.annotation.LoginUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
@@ -19,16 +21,21 @@ public class ChatController {
 
     private final ChatService chatService;
 
+    @GetMapping("/chat/history/{userId}")
+    public List<ChatResponse> getHistory(@PathVariable Long userId) {
+        return chatService.getHistory(userId);
+    }
+
     @MessageMapping("/chat.send")  // 클라이언트 → /app/chat.send
-    public void handleChat(ChatRequest request, @LoginUser Users loginUser) {
+    public void handleChat(ChatRequest request) {
         // 1) 유저 메시지 저장 + 클라이언트에게 에코
-        ChatResponse chatResponse = chatService.saveUserMessage(loginUser, request);
-        template.convertAndSend("/sub/" + loginUser.getUserId(), chatResponse);
+        ChatResponse chatResponse = chatService.saveUserMessage(request);
+        template.convertAndSend("/sub/" + request.getUserId(), chatResponse);
 
         // 2) LLM 호출 & 응답 저장 + 브로드캐스트 (동기 방식)
-        List<ChatResponse> llmResponses = chatService.askAI(loginUser, request);
+        List<ChatResponse> llmResponses = chatService.askAI(request);
         llmResponses.forEach(aiResp ->
-            template.convertAndSend("/sub/" + loginUser.getUserId(), aiResp)
+            template.convertAndSend("/sub/" + request.getUserId(), aiResp)
         );
     }
 }

--- a/MathCaptain/weakness/src/main/java/MathCaptain/weakness/domain/Chat/dto/request/ChatRequest.java
+++ b/MathCaptain/weakness/src/main/java/MathCaptain/weakness/domain/Chat/dto/request/ChatRequest.java
@@ -7,13 +7,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ChatRequest {
 
+    private Long userId;
+
     private String message;
 
-    private ChatRequest(String message) {
+    private ChatRequest(Long userId, String message) {
+        this.userId = userId;
         this.message = message;
     }
 
-    public static ChatRequest of(String message) {
-        return new ChatRequest(message);
+    public static ChatRequest of(Long userId, String message) {
+        return new ChatRequest(userId, message);
     }
 }

--- a/MathCaptain/weakness/src/main/java/MathCaptain/weakness/domain/Chat/dto/request/LLMRequest.java
+++ b/MathCaptain/weakness/src/main/java/MathCaptain/weakness/domain/Chat/dto/request/LLMRequest.java
@@ -23,7 +23,7 @@ public class LLMRequest {
         this.history = history;
     }
 
-    public static LLMRequest of(Users loginUser, ChatRequest request, List<Chat> history) {
-        return new LLMRequest(loginUser.getUserId(), request.getMessage(), history);
+    public static LLMRequest of(ChatRequest request, List<Chat> history) {
+        return new LLMRequest(request.getUserId(), request.getMessage(), history);
     }
 }

--- a/MathCaptain/weakness/src/main/java/MathCaptain/weakness/domain/Chat/entity/Chat.java
+++ b/MathCaptain/weakness/src/main/java/MathCaptain/weakness/domain/Chat/entity/Chat.java
@@ -42,8 +42,8 @@ public class Chat {
         this.message = message;
     }
 
-    public static Chat of(Users user, ChatRequest request, ChatRole role) {
-        return new Chat(user.getUserId(), role, request.getMessage());
+    public static Chat of(ChatRequest request) {
+        return new Chat(request.getUserId(), ChatRole.USER, request.getMessage());
     }
 
     public static Chat of(ChatResponse response) {

--- a/MathCaptain/weakness/src/main/java/MathCaptain/weakness/domain/Chat/service/LLMClient.java
+++ b/MathCaptain/weakness/src/main/java/MathCaptain/weakness/domain/Chat/service/LLMClient.java
@@ -31,9 +31,9 @@ public class LLMClient {
     @Value("${llm.server.url}")
     private String baseUrl;
 
-    public List<Chat> call(Users loginUser, List<Chat> history, ChatRequest request) {
+    public List<Chat> call(List<Chat> history, ChatRequest request) {
         try {
-            LLMRequest llmRequest = LLMRequest.of(loginUser, request, history);
+            LLMRequest llmRequest = LLMRequest.of(request, history);
 
             ResponseEntity<ChatResponse[]> response = restTemplate.postForEntity(
                     // TODO : 엔드포인트 수정


### PR DESCRIPTION
### 채팅
### 문제점
- 채팅 요청시 기존 @LoginUser 애노테이션이 WebSocket연결로 인해 동작하지 않음
### 해결방안 
- 프론트에서 요청시 userId를 함께 전송하여 요청하도록 수정

## 이전 채팅 기록
- 채팅 히스토리 조회 추가